### PR TITLE
Separating 'way point done' and 'order done'

### DIFF
--- a/BringgSDK.js
+++ b/BringgSDK.js
@@ -1252,18 +1252,20 @@ var BringgSDK = (function () {
     var onWayPointDone = function (){
       log('way point done');
 
+      if (callbacks.driverLeftCb) {
+        callbacks.driverLeftCb();
+      }
+    };
+
+    var onOrderDone = function (){
+      log('order done');
+
       module._closeSocketConnection();
 
       watchingDriver = false;
 
-      if (configuration.allow_rating) {
-        if (callbacks.driverLeftCb) {
-          callbacks.driverLeftCb();
-        }
-      } else {
-        if (callbacks.taskEndedCb) {
-          callbacks.taskEndedCb();
-        }
+      if (callbacks.taskEndedCb) {
+        callbacks.taskEndedCb();
       }
     };
 
@@ -1282,7 +1284,7 @@ var BringgSDK = (function () {
     module._safeSubscribe(WAY_POINT_DONE_EVENT, onWayPointDone);
     module._safeSubscribe(WAY_POINT_ETA_UPDATE_EVENT, onWayPointEtaUpdated);
     module._safeSubscribe(WAY_POINT_LOCATION_UPDATE_EVENT, onWayPointLocationUpdated);
-    module._safeSubscribe(ORDER_DONE_EVENT, onWayPointDone);
+    module._safeSubscribe(ORDER_DONE_EVENT, onOrderDone);
     module._safeSubscribe(ORDER_UPDATE_EVENT, module._onOrderUpdate);
     module._safeSubscribe(LOCATION_UPDATE_EVENT, onLocationSocketUpdated);
   };

--- a/BringgSDK.js
+++ b/BringgSDK.js
@@ -1251,11 +1251,11 @@ var BringgSDK = (function () {
       }
     };
 
-    var onWayPointDone = function (){
+    var onWayPointDone = function (eventData) {
       log('way point done');
 
       if (callbacks.driverLeftCb) {
-        callbacks.driverLeftCb();
+        callbacks.driverLeftCb(eventData);
       }
     };
 

--- a/BringgSDK.js
+++ b/BringgSDK.js
@@ -17,6 +17,7 @@ var BringgSDK = (function () {
   var LOCATION_UPDATE_EVENT = 'location update';
   var ORDER_UPDATE_EVENT = 'order update';
   var ORDER_DONE_EVENT = 'order done';
+  var ORDER_CANCELLED_EVENT = 'order cancelled';
 
   var REAL_TIME_PRODUCTION = 'https://realtime2-api.bringg.com/';
   var REAL_TIME_STAGING = 'https://staging-realtime.bringg.com/';
@@ -76,7 +77,8 @@ var BringgSDK = (function () {
       taskRatedCb: null,
       failedLoadingCb: null,
       noteAddedCb: null,
-      taskPostRatedCb: null
+      taskPostRatedCb: null,
+      taskCancelledCb: null
     },
     locationFramesInterval,
     etaInterval,
@@ -1269,6 +1271,18 @@ var BringgSDK = (function () {
       }
     };
 
+    var onOrderCancelled = function (cancellationInfo) {
+      log('order cancelled');
+
+      module._closeSocketConnection();
+
+      watchingDriver = false;
+
+      if (callbacks.taskCancelledCb) {
+        callbacks.taskCancelledCb(cancellationInfo);
+      }
+    };
+
     var onWayPointLocationUpdated = function (data) {
       log('onWayPointLocationUpdated arrived with ', JSON.stringify(data));
       lastEventTime = new Date().getTime();
@@ -1285,6 +1299,7 @@ var BringgSDK = (function () {
     module._safeSubscribe(WAY_POINT_ETA_UPDATE_EVENT, onWayPointEtaUpdated);
     module._safeSubscribe(WAY_POINT_LOCATION_UPDATE_EVENT, onWayPointLocationUpdated);
     module._safeSubscribe(ORDER_DONE_EVENT, onOrderDone);
+    module._safeSubscribe(ORDER_CANCELLED_EVENT, onOrderCancelled);
     module._safeSubscribe(ORDER_UPDATE_EVENT, module._onOrderUpdate);
     module._safeSubscribe(LOCATION_UPDATE_EVENT, onLocationSocketUpdated);
   };

--- a/demo/customer-sdk-demo.html
+++ b/demo/customer-sdk-demo.html
@@ -20,10 +20,16 @@
 
   <script type="text/javascript">
     var customer_access_token = null;
-    var my_order_uuid = 'PLACE_A_SAMPLE_ORDER_UUID_HERE'; //note that this requires the 'UUID' attribute and not the 'ID'.
+
+    /*
+     * Getting the order uuid from the url, for example:
+     *  customer-sdk-demo.html?uuid=MY_UUID
+     */
+    var my_order_uuid = location.search.substring('?uuid='.length);
+
 
     function orderUpdateCb(order){
-      console.log('orderUpdateCb' + JSON.stringify(order));
+      console.log('orderUpdateCb', order);
       // do something with order here
     }
 

--- a/demo/customer-sdk-demo.html
+++ b/demo/customer-sdk-demo.html
@@ -61,12 +61,18 @@
       // we can call BringgSDK.disconnect() if we are not using a rating screen for example.
     }
 
+    function onTaskCancelledCb(info) {
+      console.log('onTaskCancelledCb', info);
+      // task ended
+      // we can call BringgSDK.disconnect() if we are not using a rating screen for example.
+    }
+
     function onConnect(){
       console.log('onConnect');
       BringgSDK.watchOrder({
         order_uuid: my_order_uuid
       }, function (result) {
-        console.log('watch order result: ' + JSON.stringify(result));
+        console.log('watch order result: ', result);
         if (result && result.shared_location) {
           console.log('calling init bringg with ' + result.share_uuid);
           BringgSDK.initializeBringg({share_uuid: result.share_uuid}, onBringgInitSuccess, onBringgInitFailed);
@@ -106,7 +112,8 @@
       // example for setting callbacks implicitly
       BringgSDK.setEventCallback({
         'taskRatedCb': onTaskRatedCb,
-        'taskEndedCb': onTaskEndedCb
+        'taskEndedCb': onTaskEndedCb,
+        'taskCancelledCb': onTaskCancelledCb
       });
     }
   </script>


### PR DESCRIPTION
* We now close the connection on `order done` and not in `way point
done` since multiple way points can be done in a period of order.

* Remove `configuration.allow_rating` check for driver left callback,
since it feels like a bug (and roi agrees ;))

@trostik : this is something roi flagged out.
/CC: @roir 