### PR TITLE
- added support for passing customer_access_token in 'watch order' an…

### DIFF
--- a/BringgSDK.js
+++ b/BringgSDK.js
@@ -224,7 +224,7 @@ var BringgSDK = (function () {
           callback({
             success: false,
             rc: module.RETURN_CODES.missing_params,
-            error: 'watch order failed - missing params'
+            error: 'watch order failed - params must contain order_uuid and either share_uuid or customer_access_token'
           });
       }
       return;
@@ -286,7 +286,7 @@ var BringgSDK = (function () {
             callback({
                 success: false,
                 rc: module.RETURN_CODES.missing_params,
-                error: 'watch driver failed - missing params'
+                error: 'watch driver failed - params must contain driver_uuid and either share_uuid or customer_access_token'
             });
         }
         return;

--- a/BringgSDK.js
+++ b/BringgSDK.js
@@ -217,12 +217,26 @@ var BringgSDK = (function () {
    * @param callback
    */
   module.watchOrder = function (params, callback) {
+
+    if (!params || !params.order_uuid || (!params.share_uuid && !params.customer_access_token)){
+      log('watchOrder: invalid params' + JSON.stringify(params));
+      if (callback){
+          callback({
+            success: false,
+            rc: module.RETURN_CODES.missing_params,
+            error: 'watch order failed - missing params'
+          });
+      }
+      return;
+    }
+
     log('watching order :' + JSON.stringify(params));
     module._socket.emit('watch order', params, function (result) {
       module._watchOrderCb(result, callback);
 
-      // if we succeeded then use the watch params to fill missing config params
+      // if we succeeded then use the watch params to fill missing config params and credentials
       fillConfig(params);
+      module._setCredentials(params);
 
       if (!configuration.expired) {
         if (!watchingWayPoint && shouldAutoWatchWayPoint && configuration.way_point_id && configuration.order_uuid) {
@@ -266,12 +280,25 @@ var BringgSDK = (function () {
    * @param callback
    */
   module.watchDriver = function (params, callback) {
+    if (!params || !params.driver_uuid || (!params.share_uuid && !params.customer_access_token)){
+        log('watchDriver: invalid params' + JSON.stringify(params));
+        if (callback){
+            callback({
+                success: false,
+                rc: module.RETURN_CODES.missing_params,
+                error: 'watch driver failed - missing params'
+            });
+        }
+        return;
+    }
+
     log('watching driver :' + JSON.stringify(params));
     module._socket.emit('watch driver', params, function (result) {
       module._watchDriverCb(result, callback);
     });
 
     fillConfig(params);
+    module._setCredentials(params);
   };
 
   module._watchDriverCb = function (result, callback) {
@@ -863,7 +890,11 @@ var BringgSDK = (function () {
         var minTimeToWait = connected ? timeoutForRestIfSocketConnected : timeoutForRestPoll;
         if (timeSinceUpdate > minTimeToWait) {
           // poll order anyway
-          getSharedOrder(configuration.order_uuid, configuration.share_uuid);
+          getSharedOrder({
+              order_uuid: configuration.order_uuid,
+              share_uuid: configuration.share_uuid,
+              customer_access_token: module._credentials.customer_access_token
+          });
 
           // poll location only if in correct state
           if (watchingDriver) {
@@ -919,9 +950,9 @@ var BringgSDK = (function () {
     });
   }
 
-  function createShareForOrderViaRest(orderUuid) {
+  function createShareForOrderViaRest(orderUuid, customerAccessToken) {
     log('creating share via REST for order_uuid: ' + orderUuid);
-    $.getJSON(getRealTimeEndPoint() + 'shared/orders?order_uuid=' + orderUuid, function (result) {
+    $.getJSON(getRealTimeEndPoint() + 'shared/orders?order_uuid=' + orderUuid + '&customer_access_token=' + customerAccessToken, function (result) {
       log('Rest order update: ' + JSON.stringify(result));
       if (result.success && result.order_update) {
         module._onOrderUpdate(result.order_update);
@@ -931,14 +962,19 @@ var BringgSDK = (function () {
     });
   }
 
-  function getSharedOrder(orderUuid, shareUuid) {
+  function getSharedOrder(params) {
+    if (!params || !params.order_uuid) {
+      log('no order uuid for polling');
+      return;
+    }
+
     // if we already have shared location
-    if (orderUuid && shareUuid) {
-      getOrderViaRest(orderUuid, shareUuid);
-    } else if (orderUuid) { // if we don't have shared location we have to watch order first
-      createShareForOrderViaRest(orderUuid);
+    if (params.share_uuid) {
+      getOrderViaRest(params.order_uuid, params.share_uuid);
+    } else if (params.customer_access_token) {
+      createShareForOrderViaRest(params.order_uuid, params.customer_access_token);
     } else {
-      log('no shared nor order uuid for polling');
+      log('no 2nd identifier in params for polling');
     }
   }
 

--- a/BringgSDK.spec.js
+++ b/BringgSDK.spec.js
@@ -1,5 +1,9 @@
 'use strict';
 
+beforeEach(function () {
+    BringgSDK._socket = null;
+});
+
 describe('BringgSDK', function () {
   it('check the API of the service', function () {
     expect(BringgSDK._socket).toBeNull();
@@ -151,7 +155,85 @@ describe('BringgSDK', function () {
 
   describe('watch', function(){
     describe('order', function(){
-      describe('module callback', function(){
+      it('should call external callback if missing params', function(){
+          var callback = jasmine.createSpy('callback');
+          var socket = { emit: function (){} };
+          spyOn(socket, 'emit');
+
+          BringgSDK._socket = socket;
+
+          BringgSDK.watchOrder(undefined, callback);
+
+          expect(BringgSDK._socket.emit).not.toHaveBeenCalled();
+          expect(callback).toHaveBeenCalledWith({
+              success: false,
+              rc: BringgSDK.RETURN_CODES.missing_params,
+              error: 'watch order failed - missing params'
+          });
+      });
+
+      it('should call external callback if no order_uuid', function(){
+          var callback = jasmine.createSpy('callback');
+          var socket = { emit: function (){} };
+          spyOn(socket, 'emit');
+
+          BringgSDK._socket = socket;
+          BringgSDK.watchOrder({}, callback);
+
+          expect(BringgSDK._socket.emit).not.toHaveBeenCalled();
+          expect(callback).toHaveBeenCalledWith({
+              success: false,
+              rc: BringgSDK.RETURN_CODES.missing_params,
+              error: 'watch order failed - missing params'
+          });
+      });
+
+      it('should call external callback if no share_uuid and no customer_access_token', function(){
+          var callback = jasmine.createSpy('callback');
+          var socket = { emit: function (){} };
+          spyOn(socket, 'emit');
+
+          BringgSDK._socket = socket;
+
+          BringgSDK.watchOrder({order_uuid: faker.random.number()}, callback);
+
+          expect(BringgSDK._socket.emit).not.toHaveBeenCalled();
+          expect(callback).toHaveBeenCalledWith({
+              success: false,
+              rc: BringgSDK.RETURN_CODES.missing_params,
+              error: 'watch order failed - missing params'
+          });
+      });
+
+      it('should call socket.emit if order_uuid and share_uuid', function(){
+          var callback = jasmine.createSpy('callback');
+          var socket = { emit: function (){} };
+          spyOn(socket, 'emit');
+
+          BringgSDK._socket = socket;
+
+          var params = {order_uuid: faker.random.number(), share_uuid: faker.random.number()};
+          BringgSDK.watchOrder(params, callback);
+          expect(BringgSDK._socket.emit).toHaveBeenCalled();
+          expect(BringgSDK._socket.emit.calls.mostRecent().args[0]).toEqual('watch order');
+          expect(BringgSDK._socket.emit.calls.mostRecent().args[1]).toEqual(params);
+      });
+
+      it('should call socket.emit if order_uuid and customer_access_token', function(){
+          var callback = jasmine.createSpy('callback');
+          var socket = { emit: function (){} };
+          spyOn(socket, 'emit');
+
+          BringgSDK._socket = socket;
+
+          var params = {order_uuid: faker.random.number(), customer_access_token: faker.random.number()};
+          BringgSDK.watchOrder(params, callback);
+          expect(BringgSDK._socket.emit).toHaveBeenCalled();
+          expect(BringgSDK._socket.emit.calls.mostRecent().args[0]).toEqual('watch order');
+          expect(BringgSDK._socket.emit.calls.mostRecent().args[1]).toEqual(params);
+      });
+
+      describe('callback', function(){
         describe('should use external callback', function(){
           it('on no response', function(){
             var callback = jasmine.createSpy('callback');
@@ -190,8 +272,86 @@ describe('BringgSDK', function () {
     });
 
     describe('driver', function(){
-      describe('module callback', function(){
-        it('should use callback on failure', function(){
+      it('should call external callback if missing params', function(){
+          var callback = jasmine.createSpy('callback');
+          var socket = { emit: function (){} };
+          spyOn(socket, 'emit');
+
+          BringgSDK._socket = socket;
+
+          BringgSDK.watchDriver(undefined, callback);
+
+          expect(BringgSDK._socket.emit).not.toHaveBeenCalled();
+          expect(callback).toHaveBeenCalledWith({
+              success: false,
+              rc: BringgSDK.RETURN_CODES.missing_params,
+              error: 'watch driver failed - missing params'
+          });
+      });
+
+      it('should call external callback if no order_uuid', function(){
+          var callback = jasmine.createSpy('callback');
+          var socket = { emit: function (){} };
+          spyOn(socket, 'emit');
+
+          BringgSDK._socket = socket;
+          BringgSDK.watchDriver({}, callback);
+
+          expect(BringgSDK._socket.emit).not.toHaveBeenCalled();
+          expect(callback).toHaveBeenCalledWith({
+              success: false,
+              rc: BringgSDK.RETURN_CODES.missing_params,
+              error: 'watch driver failed - missing params'
+          });
+      });
+
+      it('should call external callback if no share_uuid and no customer_access_token', function(){
+          var callback = jasmine.createSpy('callback');
+          var socket = { emit: function (){} };
+          spyOn(socket, 'emit');
+
+          BringgSDK._socket = socket;
+
+          BringgSDK.watchDriver({driver_uuid: faker.random.number()}, callback);
+
+          expect(BringgSDK._socket.emit).not.toHaveBeenCalled();
+          expect(callback).toHaveBeenCalledWith({
+              success: false,
+              rc: BringgSDK.RETURN_CODES.missing_params,
+              error: 'watch driver failed - missing params'
+          });
+      });
+
+      it('should call socket.emit if order_uuid and share_uuid', function(){
+          var callback = jasmine.createSpy('callback');
+          var socket = { emit: function (){} };
+          spyOn(socket, 'emit');
+
+          BringgSDK._socket = socket;
+
+          var params = {driver_uuid: faker.random.number(), share_uuid: faker.random.number()};
+          BringgSDK.watchDriver(params, callback);
+          expect(BringgSDK._socket.emit).toHaveBeenCalled();
+          expect(BringgSDK._socket.emit.calls.mostRecent().args[0]).toEqual('watch driver');
+          expect(BringgSDK._socket.emit.calls.mostRecent().args[1]).toEqual(params);
+      });
+
+      it('should call socket.emit if order_uuid and customer_access_token', function(){
+          var callback = jasmine.createSpy('callback');
+          var socket = { emit: function (){} };
+          spyOn(socket, 'emit');
+
+          BringgSDK._socket = socket;
+
+          var params = {driver_uuid: faker.random.number(), customer_access_token: faker.random.number()};
+          BringgSDK.watchDriver(params, callback);
+          expect(BringgSDK._socket.emit).toHaveBeenCalled();
+          expect(BringgSDK._socket.emit.calls.mostRecent().args[0]).toEqual('watch driver');
+          expect(BringgSDK._socket.emit.calls.mostRecent().args[1]).toEqual(params);
+      });
+
+      describe('callback', function(){
+        it('should use external callback on failure', function(){
           var callback = jasmine.createSpy('callback');
           BringgSDK._watchDriverCb({}, callback);
           expect(callback).toHaveBeenCalledWith({success: false, rc: BringgSDK.RETURN_CODES.unknown_reason, error: 'failed watching driver'});
@@ -200,7 +360,7 @@ describe('BringgSDK', function () {
           expect(callback).toHaveBeenCalledWith({success: false, rc: BringgSDK.RETURN_CODES.no_response, error: 'failed watching driver'});
         });
 
-        it('should use callback on success', function(){
+        it('should use external callback on success', function(){
           var callback = jasmine.createSpy('callback');
           var result = {success: true};
           BringgSDK._watchDriverCb(result, callback);
@@ -254,7 +414,7 @@ describe('BringgSDK', function () {
     });
   });
 
-  describe('on new configuration', function(){
+  describe('onNewConfiguration', function(){
     it('should set eta calc interval if already watching driver', function(){
       spyOn(BringgSDK, '_setETACalcInterval');
       spyOn(BringgSDK, '_setDriverActivity');

--- a/BringgSDK.spec.js
+++ b/BringgSDK.spec.js
@@ -155,62 +155,53 @@ describe('BringgSDK', function () {
 
   describe('watch', function(){
     describe('order', function(){
-      it('should call external callback if missing params', function(){
-          var callback = jasmine.createSpy('callback');
-          var socket = { emit: function (){} };
-          spyOn(socket, 'emit');
+      describe('invalid params', function(){
+        it('should call external callback if missing params', function(){
+            var callback = jasmine.createSpy('callback');
+            BringgSDK._socket = { emit: jasmine.createSpy() };
 
-          BringgSDK._socket = socket;
+            BringgSDK.watchOrder(undefined, callback);
 
-          BringgSDK.watchOrder(undefined, callback);
-
-          expect(BringgSDK._socket.emit).not.toHaveBeenCalled();
-          expect(callback).toHaveBeenCalledWith({
+            expect(BringgSDK._socket.emit).not.toHaveBeenCalled();
+            expect(callback).toHaveBeenCalledWith({
               success: false,
               rc: BringgSDK.RETURN_CODES.missing_params,
-              error: 'watch order failed - missing params'
-          });
-      });
+              error: 'watch order failed - params must contain order_uuid and either share_uuid or customer_access_token'
+            });
+        });
 
-      it('should call external callback if no order_uuid', function(){
-          var callback = jasmine.createSpy('callback');
-          var socket = { emit: function (){} };
-          spyOn(socket, 'emit');
+        it('should call external callback if missing order_uuid', function(){
+            var callback = jasmine.createSpy('callback');
+            BringgSDK._socket = { emit: jasmine.createSpy() };
 
-          BringgSDK._socket = socket;
-          BringgSDK.watchOrder({}, callback);
+            BringgSDK.watchOrder({}, callback);
 
-          expect(BringgSDK._socket.emit).not.toHaveBeenCalled();
-          expect(callback).toHaveBeenCalledWith({
+            expect(BringgSDK._socket.emit).not.toHaveBeenCalled();
+            expect(callback).toHaveBeenCalledWith({
               success: false,
               rc: BringgSDK.RETURN_CODES.missing_params,
-              error: 'watch order failed - missing params'
-          });
-      });
+              error: 'watch order failed - params must contain order_uuid and either share_uuid or customer_access_token'
+            });
+        });
 
-      it('should call external callback if no share_uuid and no customer_access_token', function(){
-          var callback = jasmine.createSpy('callback');
-          var socket = { emit: function (){} };
-          spyOn(socket, 'emit');
+        it('should call external callback if missing share_uuid or customer_access_token', function(){
+            var callback = jasmine.createSpy('callback');
+            BringgSDK._socket = { emit: jasmine.createSpy() };
 
-          BringgSDK._socket = socket;
+            BringgSDK.watchOrder({order_uuid: faker.random.number()}, callback);
 
-          BringgSDK.watchOrder({order_uuid: faker.random.number()}, callback);
-
-          expect(BringgSDK._socket.emit).not.toHaveBeenCalled();
-          expect(callback).toHaveBeenCalledWith({
+            expect(BringgSDK._socket.emit).not.toHaveBeenCalled();
+            expect(callback).toHaveBeenCalledWith({
               success: false,
               rc: BringgSDK.RETURN_CODES.missing_params,
-              error: 'watch order failed - missing params'
-          });
+              error: 'watch order failed - params must contain order_uuid and either share_uuid or customer_access_token'
+            });
+        });
       });
 
       it('should call socket.emit if order_uuid and share_uuid', function(){
           var callback = jasmine.createSpy('callback');
-          var socket = { emit: function (){} };
-          spyOn(socket, 'emit');
-
-          BringgSDK._socket = socket;
+          BringgSDK._socket = { emit: jasmine.createSpy() };
 
           var params = {order_uuid: faker.random.number(), share_uuid: faker.random.number()};
           BringgSDK.watchOrder(params, callback);
@@ -221,10 +212,7 @@ describe('BringgSDK', function () {
 
       it('should call socket.emit if order_uuid and customer_access_token', function(){
           var callback = jasmine.createSpy('callback');
-          var socket = { emit: function (){} };
-          spyOn(socket, 'emit');
-
-          BringgSDK._socket = socket;
+          BringgSDK._socket = { emit: jasmine.createSpy() };
 
           var params = {order_uuid: faker.random.number(), customer_access_token: faker.random.number()};
           BringgSDK.watchOrder(params, callback);
@@ -272,12 +260,10 @@ describe('BringgSDK', function () {
     });
 
     describe('driver', function(){
-      it('should call external callback if missing params', function(){
+      describe('invalid params', function(){
+        it('should call external callback if missing params', function(){
           var callback = jasmine.createSpy('callback');
-          var socket = { emit: function (){} };
-          spyOn(socket, 'emit');
-
-          BringgSDK._socket = socket;
+          BringgSDK._socket = { emit: jasmine.createSpy() };
 
           BringgSDK.watchDriver(undefined, callback);
 
@@ -285,32 +271,27 @@ describe('BringgSDK', function () {
           expect(callback).toHaveBeenCalledWith({
               success: false,
               rc: BringgSDK.RETURN_CODES.missing_params,
-              error: 'watch driver failed - missing params'
+              error: 'watch driver failed - params must contain driver_uuid and either share_uuid or customer_access_token'
           });
-      });
+        });
 
-      it('should call external callback if no order_uuid', function(){
+        it('should call external callback if missing driver_uuid', function(){
           var callback = jasmine.createSpy('callback');
-          var socket = { emit: function (){} };
-          spyOn(socket, 'emit');
+          BringgSDK._socket = { emit: jasmine.createSpy() };
 
-          BringgSDK._socket = socket;
           BringgSDK.watchDriver({}, callback);
 
           expect(BringgSDK._socket.emit).not.toHaveBeenCalled();
           expect(callback).toHaveBeenCalledWith({
               success: false,
               rc: BringgSDK.RETURN_CODES.missing_params,
-              error: 'watch driver failed - missing params'
+              error: 'watch driver failed - params must contain driver_uuid and either share_uuid or customer_access_token'
           });
-      });
+        });
 
-      it('should call external callback if no share_uuid and no customer_access_token', function(){
+        it('should call external callback if missing share_uuid or customer_access_token', function(){
           var callback = jasmine.createSpy('callback');
-          var socket = { emit: function (){} };
-          spyOn(socket, 'emit');
-
-          BringgSDK._socket = socket;
+          BringgSDK._socket = { emit: jasmine.createSpy() };
 
           BringgSDK.watchDriver({driver_uuid: faker.random.number()}, callback);
 
@@ -318,30 +299,25 @@ describe('BringgSDK', function () {
           expect(callback).toHaveBeenCalledWith({
               success: false,
               rc: BringgSDK.RETURN_CODES.missing_params,
-              error: 'watch driver failed - missing params'
+              error: 'watch driver failed - params must contain driver_uuid and either share_uuid or customer_access_token'
           });
+        });
       });
 
-      it('should call socket.emit if order_uuid and share_uuid', function(){
-          var callback = jasmine.createSpy('callback');
-          var socket = { emit: function (){} };
-          spyOn(socket, 'emit');
+      it('should call socket.emit if driver_uuid and share_uuid', function(){
+        var callback = jasmine.createSpy('callback');
+        BringgSDK._socket = { emit: jasmine.createSpy() };
 
-          BringgSDK._socket = socket;
-
-          var params = {driver_uuid: faker.random.number(), share_uuid: faker.random.number()};
-          BringgSDK.watchDriver(params, callback);
-          expect(BringgSDK._socket.emit).toHaveBeenCalled();
-          expect(BringgSDK._socket.emit.calls.mostRecent().args[0]).toEqual('watch driver');
-          expect(BringgSDK._socket.emit.calls.mostRecent().args[1]).toEqual(params);
+        var params = {driver_uuid: faker.random.number(), share_uuid: faker.random.number()};
+        BringgSDK.watchDriver(params, callback);
+        expect(BringgSDK._socket.emit).toHaveBeenCalled();
+        expect(BringgSDK._socket.emit.calls.mostRecent().args[0]).toEqual('watch driver');
+        expect(BringgSDK._socket.emit.calls.mostRecent().args[1]).toEqual(params);
       });
 
-      it('should call socket.emit if order_uuid and customer_access_token', function(){
+      it('should call socket.emit if driver_uuid and customer_access_token', function(){
           var callback = jasmine.createSpy('callback');
-          var socket = { emit: function (){} };
-          spyOn(socket, 'emit');
-
-          BringgSDK._socket = socket;
+          BringgSDK._socket = { emit: jasmine.createSpy() };
 
           var params = {driver_uuid: faker.random.number(), customer_access_token: faker.random.number()};
           BringgSDK.watchDriver(params, callback);

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   ],
   "dependencies": {
     "socket.io-client": "https://github.com/liorsion/socket.io-client.git#0cd60822b6aed9fc4538009b52b0b9d0ab1c2184",
-    "jquery": "2.1.3"
+    "jquery": "~2.1.4"
   },
   "devDependencies": {
     "faker.js": "git@github.com:Marak/faker.js.git#v3.0.1"

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 4.6.0
+    version: 6.10.0
   environment:
     PATH: ${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin
 


### PR DESCRIPTION
- added support for passing customer_access_token in 'watch order' and 'watch driver' events instead of share_uuid param.
- added support for using the provided customer_access_token when requesting to generate shared location for the client.
- added validation before using watch apis that at least 2 identifiers are provided.