### PR TITLE
adds function to enable debug mode

### DIFF
--- a/BringgSDK.js
+++ b/BringgSDK.js
@@ -82,7 +82,8 @@ var BringgSDK = (function () {
     etaInterval,
     pollingInterval,
     shouldAutoWatchDriver = true,
-    shouldAutoWatchWayPoint = false;
+    shouldAutoWatchWayPoint = false,
+    debugEnabled = false;
 
   /**
    *
@@ -205,6 +206,10 @@ var BringgSDK = (function () {
 
   module.setConfiguration = function (value) {
     configuration = value;
+  };
+
+  module.setDebug = function (value) {
+    debugEnabled = value;
   };
 
 
@@ -1455,8 +1460,12 @@ var BringgSDK = (function () {
     return getRealTimeEndPoint().indexOf('localhost') != -1;
   }
 
+  function isDebug() {
+    return debugEnabled;
+  }
+
   function log(text) {
-    if (isLocal()) {
+    if (isLocal() || isDebug()) {
       console.log(text);
     }
   }

--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ if however you do not have a share_uuid but have the configuration ou can set it
 
 ##### setETAMethod(newETAMethod)
 
+##### setDebug(value)
+when running in debug mode, the app will log useful information to the console for debugging purposes.
+the `value` param should be a Boolean, either `true` or `false`.
 
 ### other
 


### PR DESCRIPTION
When working with the Bringg support team, they often request that we send them the logs from the SDK. This gives clients the ability to enable logging in the SDK so we can send the logs to the Bringg support team for debugging purposes.